### PR TITLE
Fix: Prevent UI misalignment caused by long file names

### DIFF
--- a/web/src/pages/document/index.tsx
+++ b/web/src/pages/document/index.tsx
@@ -35,7 +35,7 @@ const Content = () => {
           onClick={() => window.open(`/doc/editor/${record.id}`, '_blank')}
         >
           <Icon type='icon-bangzhuwendang1' sx={{ fontSize: 18, color: '#2f80f7' }} />
-          <Ellipsis sx={{ cursor: 'pointer' }}>
+          <Ellipsis sx={{ cursor: 'pointer', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
             {text || record.url || '-'}
           </Ellipsis>
         </Stack>


### PR DESCRIPTION
Long file names in the document list were causing the layout to break. This change applies CSS properties (overflow: hidden, white-space: nowrap, text-overflow: ellipsis) to the component responsible for displaying file names, ensuring that long names are truncated with an ellipsis instead of causing misalignment.

This addresses issue #30.