### PR TITLE
feat: 前台文档html meta 中的 title 加上文档标题

### DIFF
--- a/web/app/src/app/(pages)/(docs)/node/[id]/page.tsx
+++ b/web/app/src/app/(pages)/(docs)/node/[id]/page.tsx
@@ -1,9 +1,27 @@
 import { NodeDetail } from "@/assets/type";
+import { formatMeta } from "@/utils";
 import Doc from "@/views/node";
+import { ResolvingMetadata } from "next";
 import { headers } from "next/headers";
 
 export interface PageProps {
   params: Promise<{ id: string }>
+}
+
+export async function generateMetadata(
+  { params }: PageProps,
+  parent: ResolvingMetadata
+) {
+  const { id } = await params;
+  const headersList = await headers();
+  const kb_id = headersList.get('x-kb-id') || process.env.DEV_KB_ID || '';
+  const node = await getNodeDetail(id, kb_id);
+  return await formatMeta(
+    {
+      title: node?.name,
+    },
+    parent
+  );
 }
 
 async function getNodeDetail(id: string, kb_id: string) {

--- a/web/app/src/utils/index.ts
+++ b/web/app/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { message } from "ct-mui";
+import { ResolvingMetadata } from "next";
 
 export function addOpacityToColor(color: string, opacity: number) {
   let red, green, blue;
@@ -111,3 +112,27 @@ export const extractHeadings = (html: string) => {
     };
   });
 }
+
+
+export const formatMeta = async (
+  {
+    title,
+    description,
+    keywords,
+  }: { title?: string; description?: string; keywords?: string | string[] },
+  parent: ResolvingMetadata 
+) => {
+  const keywordsIsEmpty =
+    !keywords || (Array.isArray(keywords) && !keywords.length);
+  const {
+    title: parentTitle,
+    description: parentDescription,
+    keywords: parentKeywords,
+  } = await parent;
+
+  return {
+    title: title ? `${parentTitle?.absolute} - ${title}` : parentTitle,
+    description: description || parentDescription,
+    keywords: keywordsIsEmpty ? parentKeywords : keywords,
+  };
+};


### PR DESCRIPTION
前台文档html meta 中的 title 加上文档标题, 方便 SEO 


https://github.com/chaitin/PandaWiki/issues/175