### PR TITLE
chore: 禁止在其它供应商中非兼容openaiapi格式的 baseurl输入 & 更新zhipu 获取api key的url

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
 	github.com/boj/redistore v1.4.1
 	github.com/bwmarrin/discordgo v0.29.0
-	github.com/chaitin/ModelKit v1.8.3
+	github.com/chaitin/ModelKit v1.8.4
 	github.com/chaitin/pandawiki/sdk/rag v0.0.0-20250821111634-e0b93366d1c0
 	github.com/cloudwego/eino v0.3.51
 	github.com/cloudwego/eino-ext/components/model/deepseek v0.0.0-20250522060253-ddb617598b09

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -127,8 +127,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaitin/ModelKit v1.8.3 h1:qXhV4QYM7ZF2XZXlNQ2aaGd+9WU8K1xgThgWuP7MBNY=
-github.com/chaitin/ModelKit v1.8.3/go.mod h1:IBeqs9T8+vxMXhoer8daV0yrSPb5uaoAwQQW2Tz2qAg=
+github.com/chaitin/ModelKit v1.8.4 h1:0TbqBR5GsiKn+iVxtdoUFgFG1e3JLgdD+GbxgKh9zns=
+github.com/chaitin/ModelKit v1.8.4/go.mod h1:IBeqs9T8+vxMXhoer8daV0yrSPb5uaoAwQQW2Tz2qAg=
 github.com/chaitin/pandawiki/sdk/rag v0.0.0-20250821111634-e0b93366d1c0 h1:fePFr73w4hBmr0lp0fWbKWNGNcoZE6EYI5HPFYwkqJo=
 github.com/chaitin/pandawiki/sdk/rag v0.0.0-20250821111634-e0b93366d1c0/go.mod h1:c9cq9DFEaqynk1avg8CSOhZZOClQI1LmhCo8v7NAN3w=
 github.com/chyroc/lark v0.0.113 h1:sIW5lTCzx8DUietWfX0XTuh6BgosVT34n5HUED9pk38=

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -17,7 +17,7 @@
     "*.{js,jsx,ts,tsx,css,scss,md,mdx,json,yml,yaml,mjs,cjs}": "prettier --write"
   },
   "dependencies": {
-    "@yokowu/modelkit-ui": "0.7.4",
+    "@yokowu/modelkit-ui": "0.7.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/web/admin/pnpm-lock.yaml
+++ b/web/admin/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^2.5.0
         version: 2.8.2(react-redux@9.2.0(@types/react@19.1.10)(react@19.1.1)(redux@5.0.1))(react@19.1.1)
       '@yokowu/modelkit-ui':
-        specifier: 0.7.4
-        version: 0.7.4(c5df1a21c9b972995f7af34fdc3cfc20)
+        specifier: 0.7.6
+        version: 0.7.6(c5df1a21c9b972995f7af34fdc3cfc20)
       '@yu-cq/tiptap':
         specifier: 0.3.6
         version: 0.3.6(@tiptap/extension-code-block@3.2.1(@tiptap/core@3.2.1(@tiptap/pm@3.2.1))(@tiptap/pm@3.2.1))(@tiptap/extension-drag-handle@3.2.1(@tiptap/core@3.2.1(@tiptap/pm@3.2.1))(@tiptap/extension-collaboration@3.2.1(@tiptap/core@3.2.1(@tiptap/pm@3.2.1))(@tiptap/pm@3.2.1)(@tiptap/y-tiptap@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))(yjs@13.6.27))(@tiptap/extension-node-range@3.2.1(@tiptap/core@3.2.1(@tiptap/pm@3.2.1))(@tiptap/pm@3.2.1))(@tiptap/pm@3.2.1)(@tiptap/y-tiptap@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)))(@types/react@19.1.10)(emojibase@16.0.0)(happy-dom@18.0.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1419,8 +1419,8 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@yokowu/modelkit-ui@0.7.4':
-    resolution: {integrity: sha512-9jaQYEGugq0x+W6sTedxatWLzKu06Yl+rGjEWzwzwcho1f4oUvJu4vPu6i+S2xK6Z3Vg/hSeSudDyomLmytbhg==}
+  '@yokowu/modelkit-ui@0.7.6':
+    resolution: {integrity: sha512-wDot1xTM/wDeOua7WVw0i1BnZRwwo3sxYPE49nkjc6FFLXQc++MNeJmiX8kdbY5cPmH487nzoJQ2PStRnFaGwQ==}
 
   '@yu-cq/tiptap@0.3.6':
     resolution: {integrity: sha512-CHRTuDP/ZhuQh6SXoMkaqgl+vvhltYEZOa70ZU6LYDwSXZpydxb0qCe0flYbMpQGuz9jXW8l5QOjXurloQaHCw==}
@@ -4613,7 +4613,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@yokowu/modelkit-ui@0.7.4(c5df1a21c9b972995f7af34fdc3cfc20)':
+  '@yokowu/modelkit-ui@0.7.6(c5df1a21c9b972995f7af34fdc3cfc20)':
     dependencies:
       '@c-x/ui': 1.0.9(b591c3d2b5f46d498ca3a7f8d191cf9d)
       '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.1.1))(@types/react@19.1.10)(react@19.1.1))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
# PR 标题

禁止在其它供应商中非兼容openaiapi格式的 baseurl输入 & 更新zhipu 获取api key的url

## 变更类型

请勾选适用的变更类型:
- [ ] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [x] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: