### PR TITLE
优化了一些编辑器的功能和样式

### DIFF
--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ctzhian/modelkit": "0.0.3",
-    "@ctzhian/tiptap": "1.3.1",
+    "@ctzhian/tiptap": "1.4.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/web/admin/src/pages/document/editor/edit/Toc.tsx
+++ b/web/admin/src/pages/document/editor/edit/Toc.tsx
@@ -34,7 +34,8 @@ const HeadingSx = [
 ];
 
 const Toc = ({ headings, fixed, setFixed }: TocProps) => {
-  const [open, setOpen] = useState(false);
+  const storageTocOpen = localStorage.getItem('toc-open');
+  const [open, setOpen] = useState(!!storageTocOpen);
   const levels = Array.from(
     new Set(headings.map(it => it.originalLevel).sort((a, b) => a - b)),
   ).slice(0, 3);
@@ -122,6 +123,9 @@ const Toc = ({ headings, fixed, setFixed }: TocProps) => {
             onClick={() => {
               if (fixed) {
                 setOpen(false);
+                localStorage.removeItem('toc-open');
+              } else {
+                localStorage.setItem('toc-open', 'true');
               }
               setFixed(!fixed);
             }}

--- a/web/admin/src/pages/document/editor/edit/Wrap.tsx
+++ b/web/admin/src/pages/document/editor/edit/Wrap.tsx
@@ -35,6 +35,7 @@ const Wrap = ({ detail: defaultDetail }: WrapProps) => {
     useOutletContext<WrapContext>();
 
   // const connectCount = useRef(0);
+  const storageTocOpen = localStorage.getItem('toc-open');
 
   const isEnterprise = useMemo(() => {
     return license.edition === 2;
@@ -46,7 +47,7 @@ const Wrap = ({ detail: defaultDetail }: WrapProps) => {
   );
   const [characterCount, setCharacterCount] = useState(0);
   const [headings, setHeadings] = useState<TocList>([]);
-  const [fixedToc, setFixedToc] = useState(false);
+  const [fixedToc, setFixedToc] = useState(!!storageTocOpen);
   // const [isSyncing, setIsSyncing] = useState(false);
   // const [connectError, setConnectError] = useState(false);
   // const [collaborativeUsers, setCollaborativeUsers] = useState<

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -15,6 +15,7 @@
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
     "@cap.js/widget": "^0.1.26",
+    "@ctzhian/tiptap": "1.4.2",
     "@emotion/cache": "^11.14.0",
     "@mui/material-nextjs": "^7.1.0",
     "@sentry/nextjs": "^10.8.0",

--- a/web/app/src/views/node/Catalog.tsx
+++ b/web/app/src/views/node/Catalog.tsx
@@ -6,7 +6,7 @@ import { addExpandState } from '@/utils/drag';
 import { Box, Stack, SxProps, Tooltip } from '@mui/material';
 import { useDebounce } from 'ahooks';
 import { useParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import CatalogFolder from './CatalogFolder';
 
 const Catalog = ({ sx }: { sx?: SxProps }) => {
@@ -37,6 +37,24 @@ const Catalog = ({ sx }: { sx?: SxProps }) => {
     );
     return filterTreeBySearch(originalTree, debouncedSearchTerm);
   }, [debouncedSearchTerm]);
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const hasScrolledRef = useRef(false);
+
+  useEffect(() => {
+    if (hasScrolledRef.current) return;
+    if (!id || !catalogShow) return;
+    // 等待子项渲染完成后再滚动
+    const scrollToActive = () => {
+      const el = document.getElementById(`catalog-item-${id}`);
+      if (el) {
+        el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        hasScrolledRef.current = true;
+      }
+    };
+    const raf = requestAnimationFrame(scrollToActive);
+    return () => cancelAnimationFrame(raf);
+  }, [id, catalogShow]);
 
   if (mobile) return null;
 
@@ -126,6 +144,7 @@ const Catalog = ({ sx }: { sx?: SxProps }) => {
             width: 0,
           }),
         }}
+        ref={listRef}
       >
         {tree.map(item => (
           <CatalogFolder

--- a/web/app/src/views/node/CatalogFolder.tsx
+++ b/web/app/src/views/node/CatalogFolder.tsx
@@ -52,6 +52,7 @@ const CatalogFolder = ({
                   : 'background.paper3',
           },
         }}
+        id={`catalog-item-${item.id}`}
         onClick={() => {
           if (item.type === 1) {
             item.expanded = !item.expanded;

--- a/web/app/src/views/node/DocAnchor.tsx
+++ b/web/app/src/views/node/DocAnchor.tsx
@@ -3,7 +3,7 @@
 import useScroll from '@/utils/useScroll';
 import { TocItem, TocList } from '@ctzhian/tiptap';
 import { Box, Stack } from '@mui/material';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 interface DocAnchorProps {
   headings: TocList;
@@ -24,6 +24,9 @@ const DocAnchor = ({ headings }: DocAnchorProps) => {
     headings,
     'scroll-container',
   );
+  const activeId = activeHeading?.id;
+  const listRef = useRef<HTMLDivElement>(null);
+  const hasScrolledRef = useRef(false);
 
   const levels = Array.from(
     new Set(headings?.map(it => it.level).sort((a, b) => a - b)),
@@ -71,6 +74,18 @@ const DocAnchor = ({ headings }: DocAnchorProps) => {
     return buildTree(filteredHeadings);
   }, [headings, levels]);
 
+  useEffect(() => {
+    if (hasScrolledRef.current) return;
+    if (!activeId) return;
+    const container = listRef.current;
+    if (!container) return;
+    const el = document.getElementById(`doc-anchor-item-${activeId}`);
+    if (el) {
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      hasScrolledRef.current = true;
+    }
+  }, [activeId, headings.length]);
+
   // 递归渲染树结构的函数
   const renderTreeHeadings = (items: TreeHeading[]): React.ReactNode => {
     return (
@@ -81,6 +96,7 @@ const DocAnchor = ({ headings }: DocAnchorProps) => {
           return (
             <Stack gap={'8px'} key={heading.id}>
               <Box
+                id={`doc-anchor-item-${heading.id}`}
                 sx={{
                   cursor: 'pointer',
                   ...HeadingSx[levelIndex],
@@ -193,6 +209,7 @@ const DocAnchor = ({ headings }: DocAnchorProps) => {
             msOverflowStyle: 'none',
             scrollbarWidth: 'none',
           }}
+          ref={listRef}
         >
           {renderTreeHeadings(treeHeadings) as any}
         </Stack>

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 0.0.3
         version: 0.0.3(242fe34ca7c06b10b730209e8ea7de25)
       '@ctzhian/tiptap':
-        specifier: 1.3.1
-        version: 1.3.1(42561c31a10eb30f673aaf995a455761)
+        specifier: 1.4.2
+        version: 1.4.2(42561c31a10eb30f673aaf995a455761)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -223,6 +223,9 @@ importers:
       '@cap.js/widget':
         specifier: ^0.1.26
         version: 0.1.26
+      '@ctzhian/tiptap':
+        specifier: 1.4.2
+        version: 1.4.2(42561c31a10eb30f673aaf995a455761)
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
@@ -493,8 +496,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@ctzhian/tiptap@1.3.1':
-    resolution: {integrity: sha512-C6Mi35RRnqeztQfZwoxEVZVWUYtnWxzwe8FWEG32pyhCy8Mpfjrw25rk0hBGkzJbF0Sw3Awq175w83ttgb/K4g==}
+  '@ctzhian/tiptap@1.3.2':
+    resolution: {integrity: sha512-IGp3jjJmSN8de1Edsx1EC6CV4O+V8l8E2xMFr0c8pLPzhKwoAOdRWvKq/WZvrvPYxaGNVRrlpwfbHQngX8J50Q==}
     peerDependencies:
       '@emotion/react': ^11
       '@emotion/styled': ^11
@@ -504,8 +507,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@ctzhian/tiptap@1.3.2':
-    resolution: {integrity: sha512-IGp3jjJmSN8de1Edsx1EC6CV4O+V8l8E2xMFr0c8pLPzhKwoAOdRWvKq/WZvrvPYxaGNVRrlpwfbHQngX8J50Q==}
+  '@ctzhian/tiptap@1.4.2':
+    resolution: {integrity: sha512-SOO8HBw4xA9/lUrmc4MnUC7Fpz8VU9YqM91uwEBKLqCN+Y0D91OY91tUdiZzkM94LIE40qTciARcBMvQRKecuQ==}
     peerDependencies:
       '@emotion/react': ^11
       '@emotion/styled': ^11
@@ -874,92 +877,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -1144,28 +1133,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.4.6':
     resolution: {integrity: sha512-XBbuQddtY1p5FGPc2naMO0kqs4YYtLYK/8aPausI5lyOjr4J77KTG9mtlU4P3NwkLI1+OjsPzKVvSJdMs3cFaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.4.6':
     resolution: {integrity: sha512-+WTeK7Qdw82ez3U9JgD+igBAP75gqZ1vbK6R8PlEEuY0OIe5FuYXA4aTjL811kWPf7hNeslD4hHK2WoM9W0IgA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.4.6':
     resolution: {integrity: sha512-XP824mCbgQsK20jlXKrUpZoh/iO3vUWhMpxCz8oYeagoiZ4V0TQiKy0ASji1KK6IAe3DYGfj5RfKP6+L2020OQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.4.6':
     resolution: {integrity: sha512-FxrsenhUz0LbgRkNWx6FRRJIPe/MI1JRA4W4EPd5leXO00AZ6YU8v5vfx4MDXTvN77lM/EqsE3+6d2CIeF5NYg==}
@@ -1482,67 +1467,56 @@ packages:
     resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.0':
     resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.0':
     resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.0':
     resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
     resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.0':
     resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.0':
     resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.0':
     resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.0':
     resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.0':
     resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.0':
     resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.0':
     resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}
@@ -2372,49 +2346,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5934,7 +5900,7 @@ snapshots:
       - react-native
       - typescript
 
-  '@ctzhian/tiptap@1.3.1(42561c31a10eb30f673aaf995a455761)':
+  '@ctzhian/tiptap@1.3.2(42561c31a10eb30f673aaf995a455761)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
@@ -5992,7 +5958,7 @@ snapshots:
       - emojibase
       - happy-dom
 
-  '@ctzhian/tiptap@1.3.2(42561c31a10eb30f673aaf995a455761)':
+  '@ctzhian/tiptap@1.4.2(42561c31a10eb30f673aaf995a455761)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)


### PR DESCRIPTION
feat(fe/admin): 编辑文本页面记录大纲显示状态到本地缓存 #1181
feat(fe/app): 文档页的目录和大纲首次加载滚动到目标位置
feat(editor): Table 支持选择行列数 #751
fix(editor): MacOS 编辑文档中的表格时输入中文会留下拼音 #408 #972
fix(editor): Alert 内部支持块编辑 #1179
fix(editor): 节点互转优化转换逻辑
fix(editor): 工具栏暗黑模式下样式不统一