### PR TITLE
feat 文档相关页面支持直接跳转至前台

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -6582,6 +6582,9 @@ const docTemplate = `{
                 "position": {
                     "type": "number"
                 },
+                "publisher_id": {
+                    "type": "string"
+                },
                 "rag_info": {
                     "$ref": "#/definitions/domain.RagInfo"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6575,6 +6575,9 @@
                 "position": {
                     "type": "number"
                 },
+                "publisher_id": {
+                    "type": "string"
+                },
                 "rag_info": {
                     "$ref": "#/definitions/domain.RagInfo"
                 },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1763,6 +1763,8 @@ definitions:
         $ref: '#/definitions/domain.NodePermissions'
       position:
         type: number
+      publisher_id:
+        type: string
       rag_info:
         $ref: '#/definitions/domain.RagInfo'
       status:

--- a/backend/domain/node.go
+++ b/backend/domain/node.go
@@ -174,6 +174,7 @@ type NodeListItemResp struct {
 	EditorId    string          `json:"editor_id"`
 	Creator     string          `json:"creator"`
 	Editor      string          `json:"editor"`
+	PublisherId string          `json:"publisher_id" gorm:"-"`
 	Permissions NodePermissions `json:"permissions" gorm:"type:jsonb"`
 }
 

--- a/backend/usecase/node.go
+++ b/backend/usecase/node.go
@@ -86,6 +86,21 @@ func (u *NodeUsecase) GetList(ctx context.Context, req *domain.GetNodeListReq) (
 	if err != nil {
 		return nil, err
 	}
+	if len(nodes) == 0 {
+		return nodes, nil
+	}
+
+	publisherMap, err := u.nodeRepo.GetNodeReleasePublisherMap(ctx, req.KBID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodes {
+		if publisherID, exists := publisherMap[node.ID]; exists {
+			node.PublisherId = publisherID
+		}
+	}
+
 	return nodes, nil
 }
 


### PR DESCRIPTION
# PR 标题

feat 文档相关页面支持直接跳转至前台

## 相关 Issue

关闭或关联的 Issue (如有):
- [关联 #1510](https://github.com/chaitin/PandaWiki/issues/1510)


## 变更类型

请勾选适用的变更类型:
- [ ] Bug 修复 (不兼容变更的修复)
- [x] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. feat 文档相关页面支持直接跳转至前台
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: