### PR TITLE
fix: 侧边栏展示不齐问题, 重置提示词样式穿透问题

### DIFF
--- a/web/admin/src/components/Sidebar/index.tsx
+++ b/web/admin/src/components/Sidebar/index.tsx
@@ -134,6 +134,7 @@ const Sidebar = () => {
         position: 'fixed',
         top: 0,
         left: 0,
+        overflow: 'auto',
       }}
     >
       <Stack
@@ -156,7 +157,7 @@ const Sidebar = () => {
       >
         PandaWiki
       </Box>
-      <Stack sx={{ pt: 2, flexGrow: 1 }} gap={1}>
+      <Stack sx={{ py: 2, flexGrow: 1 }} gap={1}>
         {menus.map(it => {
           let isActive = false;
           if (it.value === '/') {

--- a/web/admin/src/pages/setting/component/CardRobotWecom.tsx
+++ b/web/admin/src/pages/setting/component/CardRobotWecom.tsx
@@ -354,7 +354,7 @@ const CardRobotWecom = ({
                         color: 'primary.main',
                         display: 'block',
                         cursor: 'pointer',
-                        zIndex: 9999,
+                        zIndex: 1,
                       }}
                       onClick={onResetPrompt}
                     >


### PR DESCRIPTION
# 修复侧边栏展示不齐问题, 重置提示词样式穿透问题


## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

