### PR TITLE
fix: group query

### DIFF
--- a/backend/store/rag/ct.go
+++ b/backend/store/rag/ct.go
@@ -67,20 +67,16 @@ func (s *CTRAG) QueryRecords(ctx context.Context, req *QueryRecordsRequest) (str
 	}
 	s.logger.Debug("retrieving by history msgs", log.Any("history_msgs", req.HistoryMsgs), log.Any("chat_msgs", chatMsgs))
 	data := &raglite.RetrieveRequest{
-		DatasetID:           req.DatasetID,
-		Query:               req.Query,
-		TopK:                10,
-		Metadata:            make(map[string]interface{}),
-		Tags:                make([]string, 0),
+		DatasetID: req.DatasetID,
+		Query:     req.Query,
+		TopK:      10,
+		Metadata: map[string]interface{}{
+			"group_ids": req.GroupIDs,
+		},
+		Tags:                req.Tags,
 		SimilarityThreshold: req.SimilarityThreshold,
 		ChatHistory:         chatMsgs,
 		MaxChunksPerDoc:     req.MaxChunksPerDoc,
-	}
-	if len(req.GroupIDs) > 0 {
-		data.Metadata["group_ids"] = req.GroupIDs
-	}
-	if len(req.Tags) > 0 {
-		data.Tags = req.Tags
 	}
 	res, err := s.client.Search.Retrieve(ctx, data)
 	if err != nil {


### PR DESCRIPTION
# PR 标题

group id 可以传空数组，用于修复用户不属于任何组的时候的文档查询过滤
## 相关 Issue

## 变更类型

请勾选适用的变更类型:
- [ x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: