### PR TITLE
fix(kb): 自动配置模型失败不进入下一步创建kb

### DIFF
--- a/backend/usecase/model.go
+++ b/backend/usecase/model.go
@@ -339,7 +339,7 @@ func (u *ModelUsecase) updateRAGModelsByMode(ctx context.Context, mode, autoMode
 			// rag store中更新失败不影响其他模型更新
 			if err := u.ragStore.UpsertModel(ctx, model); err != nil {
 				u.logger.Error("failed to update model in RAG store", log.String("model_id", model.ID), log.String("type", string(modelType)), log.Any("error", err))
-				continue
+				return fmt.Errorf("failed to update model in RAG store: %s", model.Type)
 			}
 			u.logger.Info("successfully updated RAG model", log.String("model name: ", string(model.Model)))
 		}


### PR DESCRIPTION
# PR 标题

fix(kb): 自动配置模型失败不进入下一步创建kb

## 相关 Issue

## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. fix(kb): 自动配置模型失败不进入下一步创建kb
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: