### PR TITLE
feat 静态资源独立标签页不进行查看 && 限制图片格式

### DIFF
--- a/backend/repo/pg/knowledge_base.go
+++ b/backend/repo/pg/knowledge_base.go
@@ -197,6 +197,14 @@ func (r *KnowledgeBaseRepository) SyncKBAccessSettingsToCaddy(ctx context.Contex
 								},
 								"handle": []map[string]any{
 									{
+										"handler": "headers",
+										"response": map[string]any{
+											"set": map[string][]string{
+												"Content-Disposition": {"attachment"},
+											},
+										},
+									},
+									{
 										"handler": "reverse_proxy",
 										"upstreams": []map[string]any{
 											{"dial": staticFile},

--- a/backend/utils/file.go
+++ b/backend/utils/file.go
@@ -9,7 +9,7 @@ import (
 func IsImageFile(filename string) bool {
 	ext := strings.ToLower(filepath.Ext(filename))
 	supportedImageExts := []string{
-		".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg", ".ico", ".tiff", ".tif",
+		".jpg", ".jpeg", ".png", ".webp",
 	}
 
 	return slices.Contains(supportedImageExts, ext)

--- a/web/admin/server.conf
+++ b/web/admin/server.conf
@@ -76,6 +76,8 @@ server {
 
         client_max_body_size 1000m;
 
+        add_header Content-Disposition "attachment" always;
+
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
# PR 标题

feat 静态资源独立标签页不进行查看 && 限制图片格式

## 相关 Issue

关闭或关联的 Issue (如有):
- 修复 #123
- 关联 #456

## 变更类型

请勾选适用的变更类型:
- [ ] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [x] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. feat 静态资源独立标签页不进行查看 && 限制图片格式
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: