### PR TITLE
1. 在文档编辑页面删除文档时不关闭标签页; 2. 历史版本查看的时候应该默认是当前草稿，第二个是已发布版本; 3. 统一删除按钮为红色

### DIFF
--- a/web/admin/src/components/Drag/DragTree/TreeMenu.tsx
+++ b/web/admin/src/components/Drag/DragTree/TreeMenu.tsx
@@ -9,11 +9,13 @@ export type TreeMenuItem = {
   label: string;
   onClick?: () => void;
   disabled?: boolean;
+  color?: 'error' | 'default';
   children?: {
     key: string;
     label: string;
     disabled?: boolean;
     onClick?: () => void;
+    color?: 'error' | 'default';
   }[];
 };
 
@@ -86,10 +88,18 @@ const TreeMenu = ({
                 height: 40,
                 width: 180,
                 borderRadius: '5px',
-                color: value?.disabled ? 'text.disabled' : 'text.primary',
+                color: value?.disabled
+                  ? 'text.disabled'
+                  : value.color === 'error'
+                    ? 'error.main'
+                    : 'text.primary',
                 cursor: value?.disabled ? 'not-allowed' : 'pointer',
                 ':hover': {
-                  bgcolor: addOpacityToColor(theme.palette.primary.main, 0.1),
+                  bgcolor: value?.disabled
+                    ? 'transparent'
+                    : value.color === 'error'
+                      ? addOpacityToColor(theme.palette.error.main, 0.1)
+                      : addOpacityToColor(theme.palette.primary.main, 0.1),
                 },
               }}
               onClick={value?.disabled ? undefined : value.onClick}

--- a/web/admin/src/pages/document/component/DocDelete.tsx
+++ b/web/admin/src/pages/document/component/DocDelete.tsx
@@ -13,16 +13,9 @@ interface DocDeleteProps {
   onClose: () => void;
   data: DomainNodeListItemResp[];
   onDeleted?: (ids: string[]) => void;
-  type?: 'doc' | 'list';
 }
 
-const DocDelete = ({
-  open,
-  onClose,
-  data,
-  onDeleted,
-  type = 'list',
-}: DocDeleteProps) => {
+const DocDelete = ({ open, onClose, data, onDeleted }: DocDeleteProps) => {
   const { kb_id } = useAppSelector(state => state.config);
   if (!data) return null;
 
@@ -36,11 +29,6 @@ const DocDelete = ({
       message.success('删除成功');
       onClose();
       onDeleted?.(ids);
-      if (type === 'doc') {
-        setTimeout(() => {
-          window.close();
-        }, 1500);
-      }
     });
   };
 

--- a/web/admin/src/pages/document/component/VersionRollback.tsx
+++ b/web/admin/src/pages/document/component/VersionRollback.tsx
@@ -1,7 +1,7 @@
 import { DomainNodeReleaseListItem } from '@/request/pro';
 import { Modal } from '@ctzhian/ui';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { Box, Stack } from '@mui/material';
+import { Box, Stack, alpha } from '@mui/material';
 
 interface VersionRollbackProps {
   open: boolean;
@@ -21,7 +21,6 @@ const VersionRollback = ({
     <Modal
       title={
         <Stack direction='row' alignItems='center' gap={1}>
-          <ErrorOutlineIcon sx={{ color: 'warning.main', fontSize: 24 }} />
           确认使用当前版本？
         </Stack>
       }
@@ -29,6 +28,23 @@ const VersionRollback = ({
       onOk={onOk}
       onCancel={onClose}
     >
+      <Stack
+        direction='row'
+        gap={1}
+        alignItems='center'
+        sx={{
+          py: 1,
+          px: 1.5,
+          borderRadius: 1,
+          mb: 2,
+          fontSize: 12,
+          color: 'warning.main',
+          bgcolor: theme => alpha(theme.palette.warning.main, 0.05),
+        }}
+      >
+        <ErrorOutlineIcon sx={{ color: 'warning.main', fontSize: 12 }} />
+        使用此版本会覆盖当前草稿内容
+      </Stack>
       <Stack direction='row' spacing={2}>
         <Box sx={{ fontSize: 14, width: 100, flexShrink: 0 }}>版本号</Box>
         <Box sx={{ fontWeight: 700 }}>{data.release_name}</Box>

--- a/web/admin/src/pages/document/editor/edit/Header.tsx
+++ b/web/admin/src/pages/document/editor/edit/Header.tsx
@@ -1,3 +1,4 @@
+import { ITreeItem } from '@/api';
 import Cascader from '@/components/Cascader';
 import { VersionCanUse } from '@/components/VersionMask';
 import { BUSINESS_VERSION_PERMISSION } from '@/constant/version';
@@ -61,8 +62,13 @@ const Header = ({
     return kbList?.find(item => item.id === kb_id);
   }, [kbList, kb_id]);
 
-  const { catalogOpen, nodeDetail, setCatalogOpen } =
-    useOutletContext<WrapContext>();
+  const {
+    catalogOpen,
+    nodeDetail,
+    setCatalogOpen,
+    refreshCatalog,
+    catalogData,
+  } = useOutletContext<WrapContext>();
 
   const [renameOpen, setRenameOpen] = useState(false);
   const [delOpen, setDelOpen] = useState(false);
@@ -103,6 +109,63 @@ const Header = ({
       }, 200);
     }
   }, [nodeDetail, edit]);
+
+  const handleDeleteAndNavigate = async () => {
+    // 深度优先遍历树，按照目录顺序收集所有文档
+    const collectDocs = (items: ITreeItem[]): ITreeItem[] => {
+      const docs: ITreeItem[] = [];
+      // 先对 items 按 order 排序，与 Catalog 渲染顺序保持一致
+      const sortedItems = [...items].sort(
+        (a, b) => (a.order ?? 0) - (b.order ?? 0),
+      );
+      sortedItems.forEach(item => {
+        if (item.type === 2) {
+          // 是文档，添加到列表
+          docs.push(item);
+        }
+        if (item.children && item.children.length > 0) {
+          // 递归处理子节点
+          docs.push(...collectDocs(item.children));
+        }
+      });
+      return docs;
+    };
+
+    // 使用删除前的原始数据查找下一个文档
+    const allDocs = collectDocs(catalogData);
+
+    // 找到下一个文档
+    let nextDoc = null;
+    if (allDocs.length > 0) {
+      // 找到当前文档在列表中的索引
+      const currentIndex = allDocs.findIndex(
+        (doc: ITreeItem) => doc.id === detail.id,
+      );
+
+      if (currentIndex !== -1) {
+        // 如果当前文档不是最后一个，选择下一个文档
+        if (currentIndex < allDocs.length - 1) {
+          nextDoc = allDocs[currentIndex + 1];
+        }
+        // 如果当前文档是最后一个但不是唯一的，选择前一个文档
+        else if (allDocs.length > 1) {
+          nextDoc = allDocs[currentIndex - 1];
+        }
+      }
+    }
+
+    // 刷新目录数据（删除后更新目录显示）
+    await refreshCatalog();
+
+    // 导航到下一个文档或首页
+    if (nextDoc) {
+      // 有其他文档，导航到下一个文档
+      navigate(`/doc/editor/${nextDoc.id}`);
+    } else {
+      // 没有其他文档，回到首页
+      navigate('/');
+    }
+  };
 
   useEffect(() => {
     if (nodeDetail?.updated_at && !firstLoad.current) {
@@ -256,7 +319,7 @@ const Header = ({
               {
                 key: 'delete',
                 textSx: { flex: 1 },
-                label: <StyledMenuSelect>删除</StyledMenuSelect>,
+                label: <StyledMenuSelect type='error'>删除</StyledMenuSelect>,
                 onClick: () => {
                   setDelOpen(true);
                 },
@@ -440,9 +503,11 @@ const Header = ({
         }
       />
       <DocDelete
-        type='doc'
         open={delOpen}
-        onClose={() => setDelOpen(false)}
+        onClose={() => {
+          setDelOpen(false);
+        }}
+        onDeleted={handleDeleteAndNavigate}
         data={[
           {
             ...detail,
@@ -458,25 +523,32 @@ const Header = ({
   );
 };
 
-const StyledMenuSelect = styled('div')<{ disabled?: boolean }>(
-  ({ theme, disabled = false }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between ',
-    fontSize: 14,
-    padding: theme.spacing(0, 2),
-    lineHeight: '40px',
-    height: 40,
-    minWidth: 106,
-    borderRadius: '5px',
-    color: disabled ? theme.palette.text.secondary : theme.palette.text.primary,
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    ':hover': {
-      backgroundColor: disabled
-        ? 'transparent'
+const StyledMenuSelect = styled('div')<{
+  disabled?: boolean;
+  type?: 'default' | 'error';
+}>(({ theme, disabled = false, type = 'default' }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between ',
+  fontSize: 14,
+  padding: theme.spacing(0, 2),
+  lineHeight: '40px',
+  height: 40,
+  minWidth: 106,
+  borderRadius: '5px',
+  color: disabled
+    ? theme.palette.text.secondary
+    : type === 'error'
+      ? theme.palette.error.main
+      : theme.palette.text.primary,
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  ':hover': {
+    backgroundColor: disabled
+      ? 'transparent'
+      : type === 'error'
+        ? addOpacityToColor(theme.palette.error.main, 0.1)
         : addOpacityToColor(theme.palette.primary.main, 0.1),
-    },
-  }),
-);
+  },
+}));
 
 export default Header;

--- a/web/admin/src/pages/document/editor/edit/Wrap.tsx
+++ b/web/admin/src/pages/document/editor/edit/Wrap.tsx
@@ -48,8 +48,14 @@ const Wrap = ({ detail: defaultDetail }: WrapProps) => {
   const { license } = useAppSelector(state => state.config);
 
   const state = useLocation().state as { node?: V1NodeDetailResp };
-  const { catalogOpen, setCatalogOpen, nodeDetail, setNodeDetail, onSave } =
-    useOutletContext<WrapContext>();
+  const {
+    catalogOpen,
+    setCatalogOpen,
+    nodeDetail,
+    setNodeDetail,
+    onSave,
+    catalogData,
+  } = useOutletContext<WrapContext>();
 
   const storageTocOpen = localStorage.getItem('toc-open');
 
@@ -645,8 +651,22 @@ const Wrap = ({ detail: defaultDetail }: WrapProps) => {
   }, []);
 
   useEffect(() => {
-    if (id !== defaultDetail.id) changeCatalogItem();
-  }, [id]);
+    if (id !== defaultDetail.id) {
+      // 检查当前文档是否存在于目录数据中（避免保存已删除的文档）
+      const checkDocExists = (items: typeof catalogData): boolean => {
+        for (const item of items) {
+          if (item.id === defaultDetail.id) return true;
+          if (item.children && checkDocExists(item.children)) return true;
+        }
+        return false;
+      };
+
+      // 只有文档存在时才执行保存
+      if (checkDocExists(catalogData)) {
+        changeCatalogItem();
+      }
+    }
+  }, [id, catalogData, defaultDetail.id, changeCatalogItem]);
 
   return (
     <>

--- a/web/admin/src/pages/document/index.tsx
+++ b/web/admin/src/pages/document/index.tsx
@@ -333,7 +333,12 @@ const Content = () => {
       ...(!isEditing
         ? [{ label: '重命名', key: 'rename', onClick: renameItem }]
         : []),
-      { label: '删除', key: 'delete', onClick: () => handleDelete(item) },
+      {
+        label: '删除',
+        color: 'error',
+        key: 'delete',
+        onClick: () => handleDelete(item),
+      },
     ];
   };
 

--- a/web/admin/src/pages/setting/component/UserGroup/GroupTree.tsx
+++ b/web/admin/src/pages/setting/component/UserGroup/GroupTree.tsx
@@ -428,6 +428,9 @@ export const ActionsMenu = ({
       )}
       {canEdit && (
         <MenuItem
+          sx={{
+            color: 'error.main',
+          }}
           onClick={e => {
             e.stopPropagation();
             onClose(e);


### PR DESCRIPTION
# 功能优化

简要描述这次 PR 的目的和内容
- 在文档编辑页面删除文档不要关闭标签页
- 历史版本查看的时候应该默认是当前草稿，第二个是已发布版本
- 删除用红色


## 变更类型

请勾选适用的变更类型:
- [ ] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [x] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

