### PR TITLE
fix: 首次配置模型不提示重新学习的message

### DIFF
--- a/web/admin/src/components/System/component/ModelConfig.tsx
+++ b/web/admin/src/components/System/component/ModelConfig.tsx
@@ -418,6 +418,10 @@ const ModelConfig = forwardRef<ModelConfigRef, ModelConfigProps>(
     ]);
 
     const handleSave = async () => {
+      if (!showSaveBtn) {
+        return await performSave();
+      }
+
       if (tempMode !== savedMode || hasConfigChanged) {
         // 检测是否切换了模式
         const isModeChanged = tempMode !== savedMode;
@@ -582,27 +586,29 @@ const ModelConfig = forwardRef<ModelConfigRef, ModelConfigProps>(
                   label='手动配置'
                 />
               </RadioGroup>
-              <Box
-                sx={{
-                  fontSize: 12,
-                  color: 'text.tertiary',
-                  ml: 2,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.5,
-                }}
-              >
+              {showSaveBtn && (
                 <Box
-                  component='span'
                   sx={{
-                    color: 'warning.main',
-                    fontWeight: 'bold',
+                    fontSize: 12,
+                    color: 'text.tertiary',
+                    ml: 2,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.5,
                   }}
                 >
-                  提示：
+                  <Box
+                    component='span'
+                    sx={{
+                      color: 'warning.main',
+                      fontWeight: 'bold',
+                    }}
+                  >
+                    提示：
+                  </Box>
+                  切换配置模式或修改向量模型会触发重新学习
                 </Box>
-                切换配置模式或修改向量模型会触发重新学习
-              </Box>
+              )}
             </Stack>
           </Box>
           {(tempMode !== savedMode || hasConfigChanged) && showSaveBtn && (


### PR DESCRIPTION
# 首次配置模型不提示重新学习的message


## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):
