### PR TITLE
默认配置使用 dns 代替 ip 拼接

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -97,7 +97,7 @@ func NewConfig() (*Config, error) {
 		MQ: MQConfig{
 			Type: "nats",
 			NATS: NATSConfig{
-				Server:   "panda-wiki-nats:4222",
+				Server:   "nats://panda-wiki-nats:4222",
 				User:     "panda-wiki",
 				Password: "",
 			},
@@ -105,7 +105,7 @@ func NewConfig() (*Config, error) {
 		RAG: RAGConfig{
 			Provider: "ct",
 			CTRAG: CTRAGConfig{
-				BaseURL: "panda-wiki-raglite:5050",
+				BaseURL: "http://panda-wiki-raglite:5050",
 				APIKey:  "sk-1234567890",
 			},
 		},


### PR DESCRIPTION
# PR 标题

初始化默认配置时，统一使用 dns 作为容器间服务连接地址
