### PR TITLE
fix: correct workspace filter names in root package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "icon": "pnpm --filter @panda-wiki/icons icon",
     "prepare": "cd ../ && husky web/.husky",
     "build": "pnpm --parallel --filter panda-wiki-admin --filter panda-wiki-app build",
-    "dev": "pnpm --parallel --filter admin --filter app dev"
+    "dev": "pnpm --parallel --filter panda-wiki-admin --filter panda-wiki-app dev"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,css,scss,md,mdx,json,yml,yaml,mjs,cjs}": "prettier --write --ignore-path .prettierignore"


### PR DESCRIPTION
# PR 标题
package中过滤器项目名错误

## 相关 Issue

关闭或关联的 Issue (如有):

## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容
根目录的 package.json 中使用的过滤器是 --filter admin --filter app，但实际的项目名称是 panda-wiki-admin 和 panda-wiki-app。

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: