### PR TITLE
fix: SSE请求增加HTTP错误处理及401自动跳转登录

### DIFF
--- a/web/app/src/components/QaModal/AiQaContent.tsx
+++ b/web/app/src/components/QaModal/AiQaContent.tsx
@@ -11,7 +11,7 @@ import { postShareV1ChatFeedback } from '@/request/ShareChat';
 import { getShareV1ConversationDetail } from '@/request/ShareConversation';
 import { postShareV1CommonFileUpload } from '@/request/ShareFile';
 import { copyText } from '@/utils';
-import SSEClient from '@/utils/fetch';
+import SSEClient, { SSEHttpError } from '@/utils/fetch';
 import { Image as ImagePreview, message } from '@ctzhian/ui';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -614,6 +614,16 @@ const AiQaContent: React.FC<{
       url: `${basePath}/share/v1/chat/message`,
       headers: {
         'Content-Type': 'application/json',
+      },
+      onError: error => {
+        setLoading(false);
+        setThinking(4);
+        if (error instanceof SSEHttpError && error.status === 401) {
+          const current = window.location;
+          window.location.href = `${basePath}/auth/login?redirect=${encodeURIComponent(current.pathname + current.search)}`;
+          return;
+        }
+        message.error(error.message || '请求失败');
       },
       onCancel: () => {
         setLoading(false);

--- a/web/app/src/utils/fetch.ts
+++ b/web/app/src/utils/fetch.ts
@@ -2,6 +2,15 @@ type SSECallback<T> = (data: T) => void;
 type SSEErrorCallback = (error: Error) => void;
 type SSECompleteCallback = () => void;
 
+export class SSEHttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'SSEHttpError';
+    this.status = status;
+  }
+}
+
 interface SSEClientOptions {
   url: string;
   headers?: Record<string, string>;
@@ -63,7 +72,13 @@ class SSEClient<T> {
       .then(async response => {
         if (!response.ok) {
           clearTimeout(timeoutId);
-          throw new Error(`HTTP error! status: ${response.status}`);
+          let errorMessage = `HTTP error! status: ${response.status}`;
+          try {
+            const body = await response.json();
+            if (body?.message) errorMessage = body.message;
+            else if (body?.error) errorMessage = body.error;
+          } catch {}
+          throw new SSEHttpError(response.status, errorMessage);
         }
         if (!response.body) {
           clearTimeout(timeoutId);


### PR DESCRIPTION
新增SSEHttpError类以携带HTTP状态码，SSE请求失败时解析响应体获取错误信息，
401错误自动重定向到登录页面。

## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):