### PR TITLE
fix: 移动端 logo 过长导致 header 内容堆叠

### DIFF
--- a/web/packages/ui/src/header/index.tsx
+++ b/web/packages/ui/src/header/index.tsx
@@ -149,12 +149,27 @@ const Header = React.memo(
                 color: 'text.primary',
                 textDecoration: 'none',
                 '&:hover': { color: 'primary.main' },
+                ...(mobile && {
+                  minWidth: 0,
+                  overflow: 'hidden',
+                }),
               }}
             >
-              {logo && <img src={logo} alt='logo' height={36} />}
+              {logo && (
+                <img
+                  src={logo}
+                  alt='logo'
+                  height={36}
+                  style={{
+                    flexShrink: mobile ? 1 : 0,
+                    maxWidth: mobile ? '100%' : 'none',
+                    objectFit: 'contain',
+                  }}
+                />
+              )}
               <Box
                 sx={{
-                  fontSize: 20,
+                  fontSize: mobile ? 16 : 20,
                   whiteSpace: 'nowrap',
                   textOverflow: 'ellipsis',
                   overflow: 'hidden',

--- a/web/packages/ui/src/welcomeHeader/index.tsx
+++ b/web/packages/ui/src/welcomeHeader/index.tsx
@@ -175,12 +175,27 @@ const Header = React.memo(
                 color: 'text.primary',
                 textDecoration: 'none',
                 '&:hover': { color: 'primary.main' },
+                ...(mobile && {
+                  minWidth: 0,
+                  overflow: 'hidden',
+                }),
               }}
             >
-              {logo && <img src={logo} alt='logo' height={36} />}
+              {logo && (
+                <img
+                  src={logo}
+                  alt='logo'
+                  height={36}
+                  style={{
+                    flexShrink: mobile ? 1 : 0,
+                    maxWidth: mobile ? '100%' : 'none',
+                    objectFit: 'contain',
+                  }}
+                />
+              )}
               <Box
                 sx={{
-                  fontSize: 20,
+                  fontSize: mobile ? 16 : 20,
                   whiteSpace: 'nowrap',
                   textOverflow: 'ellipsis',
                   overflow: 'hidden',


### PR DESCRIPTION

# 修复移动端 logo 和标题改为自适应剩余空间，避免与搜索框/按钮重叠


## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):
