### PR TITLE
fix(app) editor perms 修复后台编辑页面普通用户无法获取知识库配置信息

### DIFF
--- a/backend/handler/v1/app.go
+++ b/backend/handler/v1/app.go
@@ -35,10 +35,10 @@ func NewAppHandler(e *echo.Echo, baseHandler *handler.BaseHandler, logger *log.L
 		config:              config,
 	}
 
-	group := e.Group("/api/v1/app", h.auth.Authorize, h.auth.ValidateKBUserPerm(consts.UserKBPermissionFullControl))
-	group.GET("/detail", h.GetAppDetail)
-	group.PUT("", h.UpdateApp)
-	group.DELETE("", h.DeleteApp)
+	group := e.Group("/api/v1/app", h.auth.Authorize)
+	group.GET("/detail", h.GetAppDetail, h.auth.ValidateKBUserPerm(consts.UserKBPermissionDocManage))
+	group.PUT("", h.UpdateApp, h.auth.ValidateKBUserPerm(consts.UserKBPermissionFullControl))
+	group.DELETE("", h.DeleteApp, h.auth.ValidateKBUserPerm(consts.UserKBPermissionFullControl))
 
 	return h
 }
@@ -72,6 +72,9 @@ func (h *AppHandler) GetAppDetail(c echo.Context) error {
 	app, err := h.usecase.GetAppDetailByKBIDAndAppType(ctx, kbID, domain.AppType(appTypeInt))
 	if err != nil {
 		return h.NewResponseWithError(c, "get app detail failed", err)
+	}
+	if authInfo := domain.GetAuthInfoFromCtx(ctx); authInfo != nil && authInfo.Permission == consts.UserKBPermissionDocManage {
+		app = h.usecase.SanitizeAppDetailForDocManage(app)
 	}
 	return h.NewResponseWithData(c, app)
 }

--- a/backend/usecase/app.go
+++ b/backend/usecase/app.go
@@ -587,6 +587,37 @@ func (u *AppUsecase) GetAppDetailByKBIDAndAppType(ctx context.Context, kbID stri
 	return appDetailResp, nil
 }
 
+func (u *AppUsecase) SanitizeAppDetailForDocManage(app *domain.AppDetailResp) *domain.AppDetailResp {
+	if app == nil {
+		return nil
+	}
+
+	sanitized := &domain.AppDetailResp{
+		ID:   app.ID,
+		KBID: app.KBID,
+		Name: app.Name,
+		Type: app.Type,
+	}
+
+	if app.Type != domain.AppTypeWeb {
+		return sanitized
+	}
+
+	sanitized.Settings = domain.AppSettingsResp{
+		ThemeMode:           app.Settings.ThemeMode,
+		ThemeAndStyle:       app.Settings.ThemeAndStyle,
+		CatalogSettings:     app.Settings.CatalogSettings,
+		WatermarkContent:    app.Settings.WatermarkContent,
+		WatermarkSetting:    app.Settings.WatermarkSetting,
+		CopySetting:         app.Settings.CopySetting,
+		ContributeSettings:  app.Settings.ContributeSettings,
+		ConversationSetting: app.Settings.ConversationSetting,
+		HomePageSetting:     app.Settings.HomePageSetting,
+	}
+
+	return sanitized
+}
+
 func (u *AppUsecase) GetMCPServerAppInfo(ctx context.Context, kbID string) (*domain.AppInfoResp, error) {
 	apiApp, err := u.repo.GetOrCreateAppByKBIDAndType(ctx, kbID, domain.AppTypeMcpServer)
 	if err != nil {


### PR DESCRIPTION
# PR 标题

修复后台编辑页面普通用户无法获取知识库配置信息


## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. 修复后台编辑页面普通用户无法获取知识库配置信息
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: