### PR TITLE
fix: 修复节点创建时 PostgreSQL invalid byte sequence 错误

### DIFF
--- a/backend/repo/pg/node.go
+++ b/backend/repo/pg/node.go
@@ -107,8 +107,9 @@ func (r *NodeRepository) Create(ctx context.Context, req *domain.CreateNodeReq, 
 			UpdatedAt: now,
 			EditTime:  now,
 			RagInfo: domain.RagInfo{
-				Status:  consts.NodeRagStatusPending,
-				Message: "",
+				Status:   consts.NodeRagStatusPending,
+				Message:  "",
+				SyncedAt: now,
 			},
 			Permissions: domain.NodePermissions{
 				Answerable: consts.NodeAccessPermOpen,


### PR DESCRIPTION
问题描述：
  创建节点时数据库报错: invalid byte sequence for encoding "UTF8": 0x00 (SQLSTATE 22021)

根因分析：
  在 repo/pg/node.go 的 Create 方法中，创建 RagInfo 结构体时未初始化 SyncedAt 字段，
  导致其为 time.Time 零值。当 GORM 将 RagInfo 序列化写入 PostgreSQL JSONB 字段时，
  零值 time.Time 可能产生数据库无法接受的格式或包含非法字节。

错误日志证据：
  - rag_info 显示为非标准 JSON 格式: [PENDING  0001-01-01 00:00:00 +0000 UTC]
  - permissions 显示异常: {open open open}
  - 这表明序列化过程存在问题

修复方案：
  在创建 RagInfo 时显式初始化 SyncedAt 字段为当前时间，避免 time.Time 零值问题。

影响范围：
  - backend/repo/pg/node.go: Create 方法

测试建议：
  - 使用包含特殊字符的内容创建节点
  - 验证 rag_info 字段正确存储为标准 JSON 格式
  - 确认 permissions 字段正确序列化

# PR 标题

简要描述这次 PR 的目的和内容

## 相关 Issue

关闭或关联的 Issue (如有):
- 修复 #123
- 关联 #456

## 变更类型

请勾选适用的变更类型:
- [ ] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. 
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [ ] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: