### PR TITLE
fix: add error logging to empty catch blocks

### DIFF
--- a/web/admin/src/components/ShowText/index.tsx
+++ b/web/admin/src/components/ShowText/index.tsx
@@ -71,7 +71,7 @@ const ShowText = ({
                     if (ok) message.success('复制成功');
                     document.body.removeChild(ta);
                   }
-                } catch (e) {}
+                } catch (e) { console.warn("[PandaWiki] Parse error:", e); }
                 onClick?.();
               } else {
                 copyText(content);

--- a/web/app/src/components/markdown2/mermaidRenderer.tsx
+++ b/web/app/src/components/markdown2/mermaidRenderer.tsx
@@ -50,7 +50,7 @@ export const createMermaidRenderer = (
         mermaidSuccessIdRef.current?.set(mermaidCount, renderResult.svg);
         const mermaidContainer = document.querySelector(`.${className}`);
         mermaidContainer!.innerHTML = renderResult.svg;
-      } catch (renderError) {}
+      } catch (renderError) { console.warn("[PandaWiki] Mermaid render error:", renderError); }
     });
 
     return `<pre><div class="mermaid-container ${className}">${svg}</div></pre>`;

--- a/web/app/src/request/httpClient.ts
+++ b/web/app/src/request/httpClient.ts
@@ -312,7 +312,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
       try {
         data = await response[responseFormat]();
-      } catch (error) {}
+      } catch (error) { console.warn("[PandaWiki] Response parse error:", error); }
 
       if (cancelToken) {
         this.abortControllers.delete(cancelToken);

--- a/web/app/src/request/pro/httpClient.ts
+++ b/web/app/src/request/pro/httpClient.ts
@@ -312,7 +312,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
       try {
         data = await response[responseFormat]();
-      } catch (error) {}
+      } catch (error) { console.warn("[PandaWiki] Response parse error:", error); }
 
       if (cancelToken) {
         this.abortControllers.delete(cancelToken);

--- a/web/app/src/views/editor/index.tsx
+++ b/web/app/src/views/editor/index.tsx
@@ -78,7 +78,7 @@ const DocEditor = () => {
               try {
                 window.open('', '_self');
                 window.close();
-              } catch {}
+              } catch (e) { console.warn("[PandaWiki] Editor error:", e); }
               // 最终兜底：跳转到首页
               setTimeout(() => {
                 if (!document.hidden) {
@@ -87,7 +87,7 @@ const DocEditor = () => {
               }, 50);
             }
           }, 0);
-        } catch {}
+        } catch (e) { console.warn("[PandaWiki] Editor error:", e); }
       }, 3000);
     });
   };


### PR DESCRIPTION
## Problem

6 empty catch blocks across 5 files silently swallow errors:

- `httpClient.ts` (×2): Response parsing errors are invisible — if the server returns malformed JSON, `data` silently stays `undefined`
- `mermaidRenderer.tsx`: Mermaid diagram render failures are hidden
- `editor/index.tsx` (×2): Editor errors are suppressed
- `ShowText/index.tsx`: Content parse errors are silenced

## Fix

Add `console.warn` to all empty catch blocks:

```typescript
// Before
} catch (error) {}

// After  
} catch (error) { console.warn("[PandaWiki] Response parse error:", error); }
```

- **5 files, 6 catches** updated
- **Behavior unchanged** — errors are caught, not thrown
- **Debugging improved** — errors are now visible in console

Found during a [static analysis sweep of 97 popular open source projects](https://dev.to/_1353e04f14b156240b/i-scanned-50-popular-open-source-projects-for-security-patterns-heres-what-i-found-8l5).