### PR TITLE
fix: preserve model active state when syncing raglite 修复单独更新向量模型导致状态同步异常

### DIFF
--- a/backend/repo/pg/model.go
+++ b/backend/repo/pg/model.go
@@ -104,6 +104,17 @@ func (r *ModelRepository) GetModelByType(ctx context.Context, modelType domain.M
 	return &model, nil
 }
 
+func (r *ModelRepository) GetModelByID(ctx context.Context, modelID string) (*domain.Model, error) {
+	var model domain.Model
+	if err := r.db.WithContext(ctx).
+		Model(&domain.Model{}).
+		Where("id = ?", modelID).
+		First(&model).Error; err != nil {
+		return nil, err
+	}
+	return &model, nil
+}
+
 func (r *ModelRepository) UpdateUsage(ctx context.Context, modelID string, usage *schema.TokenUsage) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// update model usage

--- a/backend/usecase/model.go
+++ b/backend/usecase/model.go
@@ -116,22 +116,11 @@ func (u *ModelUsecase) Update(ctx context.Context, req *domain.UpdateModelReq) e
 	if err := u.modelRepo.Update(ctx, req); err != nil {
 		return err
 	}
-	data := &domain.Model{
-		Provider:   req.Provider,
-		Model:      req.Model,
-		Type:       req.Type,
-		APIKey:     req.APIKey,
-		BaseURL:    req.BaseURL,
-		APIHeader:  req.APIHeader,
-		APIVersion: req.APIVersion,
+	model, err := u.modelRepo.GetModelByID(ctx, req.ID)
+	if err != nil {
+		return err
 	}
-	if req.IsActive != nil {
-		data.IsActive = *req.IsActive
-	}
-	if req.Parameters != nil {
-		data.Parameters = *req.Parameters
-	}
-	if err := u.ragStore.UpsertModel(ctx, data); err != nil {
+	if err := u.ragStore.UpsertModel(ctx, model); err != nil {
 		return err
 	}
 	// 模型更新成功后，如果更新嵌入模型，则触发记录更新


### PR DESCRIPTION
# PR 标题

简要描述这次 PR 的目的和内容

## 相关 Issue

关闭或关联的 Issue (如有):
- 修复 [#1801](https://github.com/chaitin/PandaWiki/issues/1801) 
- https://github.com/chaitin/PandaWiki/issues/1787
- https://github.com/chaitin/PandaWiki/issues/1799

## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. 修复单独更新向量模型导致状态同步异常
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: