### PR TITLE
fix: only show legacy auto-config warning when api key is set

### DIFF
--- a/web/admin/src/components/System/component/ModelConfig.tsx
+++ b/web/admin/src/components/System/component/ModelConfig.tsx
@@ -172,6 +172,7 @@ const ModelConfig = forwardRef<ModelConfigRef, ModelConfigProps>(
             }
             setIsLegacyAutoConfig(
               isAuto &&
+                !!setting.auto_mode_api_key &&
                 (!setting.auto_mode_provider ||
                   setting.auto_mode_provider === 'BaiZhiCloud'),
             );


### PR DESCRIPTION
# PR 标题

fix: only show legacy auto-config warning when api key is set


## 变更类型

请勾选适用的变更类型:
- [x] Bug 修复 (不兼容变更的修复)
- [ ] 新功能 (不兼容变更的新功能)
- [ ] 功能改进 (不兼容现有功能的改进)
- [ ] 文档更新
- [ ] 依赖更新
- [ ] 重构 (不影响功能的代码修改)
- [ ] 测试用例
- [ ] CI/CD 配置变更
- [ ] 其他 (请描述):

## 变更内容

详细描述本次 PR 的具体变更内容:
1. fix: only show legacy auto-config warning when api key is set
2. 
3. 

## 测试情况

描述本次变更的测试情况:
- [x] 已本地测试
- [ ] 已添加测试用例
- [ ] 不需要测试 (理由: )

## 其他说明

任何其他需要说明的事项: