### PR TITLE
feat: add node export API for Markdown and HTML formats

### DIFF
--- a/backend/api/node/v1/node.go
+++ b/backend/api/node/v1/node.go
@@ -98,3 +98,9 @@ type NodeListGroupNavResp struct {
 	IsReleased bool                      `json:"is_released"`
 	List       []domain.NodeListItemResp `json:"list"`
 }
+
+type NodeExportReq struct {
+	ID     string `query:"id" json:"id" validate:"required"`
+	KbId   string `query:"kb_id" json:"kb_id" validate:"required"`
+	Format string `query:"format" json:"format" validate:"required,oneof=md html"`
+}

--- a/backend/handler/v1/node.go
+++ b/backend/handler/v1/node.go
@@ -61,6 +61,8 @@ func NewNodeHandler(
 	group.GET("/permission", h.NodePermission)
 	group.PATCH("/permission/edit", h.NodePermissionEdit)
 
+	group.GET("/export", h.ExportNode)
+
 	return h
 }
 
@@ -562,4 +564,38 @@ func (h *NodeHandler) NodeRestudy(c echo.Context) error {
 	}
 
 	return h.NewResponseWithData(c, nil)
+}
+
+// ExportNode 导出节点为 Markdown 或 HTML 格式
+//
+//	@Tags			Node
+//	@Summary		导出节点
+//	@Description	导出节点为 Markdown 或 HTML 格式
+//	@ID				v1-ExportNode
+//	@Accept			json
+//	@Produce		json
+//	@Security		bearerAuth
+//	@Param			param	query		v1.NodeExportReq	true	"导出参数"
+//	@Success		200		{object}	domain.Response{data=map[string]string}
+//	@Router			/api/v1/node/export [get]
+func (h *NodeHandler) ExportNode(c echo.Context) error {
+	var req v1.NodeExportReq
+	if err := c.Bind(&req); err != nil {
+		return h.NewResponseWithError(c, "request params is invalid", err)
+	}
+
+	if err := c.Validate(req); err != nil {
+		return h.NewResponseWithError(c, "validate request params failed", err)
+	}
+
+	ctx := c.Request().Context()
+	content, filename, err := h.usecase.ExportNode(ctx, &req)
+	if err != nil {
+		return h.NewResponseWithError(c, "export node failed", err)
+	}
+
+	return h.NewResponseWithData(c, map[string]string{
+		"content":  content,
+		"filename": filename,
+	})
 }

--- a/backend/usecase/node.go
+++ b/backend/usecase/node.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/html"
@@ -137,6 +138,58 @@ func (u *NodeUsecase) GetNodeByKBID(ctx context.Context, id, kbId, format string
 		}
 	}
 	return node, nil
+}
+
+func (u *NodeUsecase) ExportNode(ctx context.Context, req *v1.NodeExportReq) (string, string, error) {
+	node, err := u.nodeRepo.GetByID(ctx, req.ID, req.KbId)
+	if err != nil {
+		return "", "", err
+	}
+
+	var content string
+	var filename string
+
+	switch req.Format {
+	case "md":
+		content = node.Content
+		if node.Meta.ContentType == domain.ContentTypeHTML {
+			// Convert HTML to Markdown if needed
+			content = u.convertHTMLToMarkdown(content)
+		}
+		filename = fmt.Sprintf("%s.md", node.Name)
+	case "html":
+		content = node.Content
+		if node.Meta.ContentType == domain.ContentTypeMD {
+			content = u.convertMDToHTML(content)
+		}
+		filename = fmt.Sprintf("%s.html", node.Name)
+	default:
+		return "", "", errors.New("unsupported export format")
+	}
+
+	return content, filename, nil
+}
+
+func (u *NodeUsecase) convertHTMLToMarkdown(htmlContent string) string {
+	// Simple HTML to Markdown conversion
+	// This is a basic implementation - can be enhanced with more robust libraries
+	md := htmlContent
+	// Remove HTML tags and convert to basic markdown
+	md = strings.ReplaceAll(md, "<p>", "\n\n")
+	md = strings.ReplaceAll(md, "</p>", "")
+	md = strings.ReplaceAll(md, "<br>", "\n")
+	md = strings.ReplaceAll(md, "<br/>", "\n")
+	md = strings.ReplaceAll(md, "<strong>", "**")
+	md = strings.ReplaceAll(md, "</strong>", "**")
+	md = strings.ReplaceAll(md, "<em>", "*")
+	md = strings.ReplaceAll(md, "</em>", "*")
+	md = strings.ReplaceAll(md, "<h1>", "# ")
+	md = strings.ReplaceAll(md, "</h1>", "\n")
+	md = strings.ReplaceAll(md, "<h2>", "## ")
+	md = strings.ReplaceAll(md, "</h2>", "\n")
+	md = strings.ReplaceAll(md, "<h3>", "### ")
+	md = strings.ReplaceAll(md, "</h3>", "\n")
+	return strings.TrimSpace(md)
 }
 
 func (u *NodeUsecase) NodeAction(ctx context.Context, req *domain.NodeActionReq) error {


### PR DESCRIPTION
## Summary

Add node export API that allows users to export knowledge base nodes in Markdown or HTML format with automatic format conversion.

## Changes

- Add `NodeExportReq` struct with id, kb_id, and format parameters
- Implement `ExportNode` usecase method with format conversion support
- Add `convertHTMLToMarkdown` helper for HTML to Markdown conversion
- Add `ExportNode` handler with proper validation and error handling
- Register `GET /api/v1/node/export` endpoint

## API Usage

```
GET /api/v1/node/export?id={node_id}&kb_id={kb_id}&format=md
GET /api/v1/node/export?id={node_id}&kb_id={kb_id}&format=html
```

## Test Plan

- [ ] Test Markdown format export
- [ ] Test HTML format export
- [ ] Test automatic format conversion
- [ ] Test invalid parameter handling
