### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ SUCCESS    密码: **********************
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=chaitin/PandaWiki&type=Date)](https://www.star-history.com/#chaitin/PandaWiki&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=chaitin/PandaWiki&type=Date)](https://star-history.dera.page/#chaitin/PandaWiki&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to a working alternative so visitors can see the project's growth again.